### PR TITLE
Fix TestPyPI Publish

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,12 @@
 
 ## Getting started
 
-We use Docker as a clean, reproducible development environment within which to build, test, generate docs, and so on. As long as you have a modern version of Docker, you should be able to run the full test suite using the `cicd/test.sh` shell script, discussed [below](#tests). That's it! Of course, running things natively isn't a supported/maintained thing.
+We use
+- [`uv`](https://docs.astral.sh/uv/) as a Python project and package manager
+- [`just`](https://just.systems/) as a command runner
+- [`git`](https://git-scm.com/) as a distributed version control system
+
+That should be all you need to install!
 
 ## Tests
 

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Publish to TestPyPI
         if: ${{ github.ref == 'refs/heads/main' }}
-        run: just publish testpypi
+        run: just publish repository=testpypi
 
   os_compatibility:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary

Update contirbuting docs to remove docker refs, and fix publish to testpypi cicd config

### Why?

Broken and out of date.

### How?

Use `repository=testpypi`.

## Mantra

_Remember, "Slow is smooth, and smooth is fast"._

If you have any questions not answered by a quick readthrough of the [contributor guide](https://tubthumper.mattefay.com/en/latest/contributor_guide.html), add them to this PR and submit it.
