### PR TITLE
Fix publish to testpypi command, again

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Publish to TestPyPI
         if: ${{ github.ref == 'refs/heads/main' }}
-        run: just publish repository=testpypi
+        run: just repository=testpypi publish
 
   os_compatibility:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary

Fix publish to testpypi command, again

### Why?

Still broke

### How?

Options go before commands in just, apparently.

## Mantra

_Remember, "Slow is smooth, and smooth is fast"._

If you have any questions not answered by a quick readthrough of the [contributor guide](https://tubthumper.mattefay.com/en/latest/contributor_guide.html), add them to this PR and submit it.
