### PR TITLE
Add just install fix to release CI workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,5 +25,8 @@ jobs:
         with:
           python-version-file: ".python-version"
 
+      - name: Install just
+        uses: extractions/setup-just@v2
+
       - name: Publish package to pypi
         run: just publish


### PR DESCRIPTION
## Summary

Add just install fix to release CI workflow

### Why?

Release workflow is broken

### How?

Extra config step

## Mantra

_Remember, "Slow is smooth, and smooth is fast"._

If you have any questions not answered by a quick readthrough of the [contributor guide](https://tubthumper.mattefay.com/en/latest/contributor_guide.html), add them to this PR and submit it.
